### PR TITLE
fix: move Hono to peerDependencies

### DIFF
--- a/.changeset/early-brooms-kiss.md
+++ b/.changeset/early-brooms-kiss.md
@@ -1,0 +1,8 @@
+---
+"@hono-storage/node-disk": patch
+"@hono-storage/memory": patch
+"@hono-storage/core": patch
+"@hono-storage/s3": patch
+---
+
+Move Hono to peerDependencies. Hono Storage now has compatibility with Hono v3.8 or later.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,12 @@
   "author": "sor4chi",
   "license": "MIT",
   "dependencies": {
-    "@web-std/file": "^3.0.3",
+    "@web-std/file": "^3.0.3"
+  },
+  "devDependencies": {
     "hono": "^4.3.2"
+  },
+  "peerDependencies": {
+    "hono": ">=3.8"
   }
 }

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -27,10 +27,13 @@
   "author": "sor4chi",
   "license": "MIT",
   "dependencies": {
-    "@hono-storage/core": "workspace:*",
-    "hono": "^4.3.2"
+    "@hono-storage/core": "workspace:*"
   },
   "devDependencies": {
-    "vitest": "^0.34.5"
+    "vitest": "^0.34.5",
+    "hono": "^4.3.2"
+  },
+  "peerDependencies": {
+    "hono": ">=3.8"
   }
 }

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1,5 +1,6 @@
 import { HonoStorage, HonoStorageFile } from "@hono-storage/core";
-import { Context } from "hono";
+
+import type { Context } from "hono";
 
 type HMSFunction = (c: Context, file: HonoStorageFile) => string;
 

--- a/packages/node-disk/package.json
+++ b/packages/node-disk/package.json
@@ -31,13 +31,16 @@
   "license": "MIT",
   "dependencies": {
     "@hono-storage/core": "workspace:*",
-    "@web-std/file": "^3.0.3",
-    "hono": "^4.3.2"
+    "@web-std/file": "^3.0.3"
   },
   "devDependencies": {
     "@hono/node-server": "^1.2.0",
     "@types/node": "^18.7.6",
     "@types/supertest": "^2.0.12",
-    "supertest": "^6.3.3"
+    "supertest": "^6.3.3",
+    "hono": "^4.3.2"
+  },
+  "peerDependencies": {
+    "hono": ">=3.8"
   }
 }

--- a/packages/node-disk/src/index.ts
+++ b/packages/node-disk/src/index.ts
@@ -4,7 +4,8 @@ import { join } from "path";
 
 import { HonoStorage, HonoStorageFile } from "@hono-storage/core";
 import { File } from "@web-std/file";
-import { Context } from "hono";
+
+import type { Context } from "hono";
 
 type HDSCustomFunction = (c: Context, file: HonoStorageFile) => string;
 

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -32,11 +32,14 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.428.0",
     "@aws-sdk/s3-request-presigner": "3.428.0",
-    "@hono-storage/core": "workspace:*",
-    "hono": "^4.3.2"
+    "@hono-storage/core": "workspace:*"
   },
   "devDependencies": {
     "@smithy/types": "^2.4.0",
-    "@web-std/file": "^3.0.3"
+    "@web-std/file": "^3.0.3",
+    "hono": "^4.3.2"
+  },
+  "peerDependencies": {
+    "hono": ">=3.8"
   }
 }

--- a/packages/s3/src/index.ts
+++ b/packages/s3/src/index.ts
@@ -6,7 +6,6 @@ import {
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { HonoStorageFile } from "@hono-storage/core";
 import { RequestPresigningArguments } from "@smithy/types";
-import { Context } from "hono";
 
 import {
   BaseHonoS3Storage,
@@ -14,6 +13,8 @@ import {
   IS3Object,
   IS3Sign,
 } from "./storage";
+
+import type { Context } from "hono";
 
 class S3Repository implements IS3Object, IS3Sign {
   private client: S3Client;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,7 @@ importers:
       '@web-std/file':
         specifier: ^3.0.3
         version: 3.0.3
+    devDependencies:
       hono:
         specifier: ^4.3.2
         version: 4.3.2
@@ -188,10 +189,10 @@ importers:
       '@hono-storage/core':
         specifier: workspace:*
         version: link:../core
+    devDependencies:
       hono:
         specifier: ^4.3.2
         version: 4.3.2
-    devDependencies:
       vitest:
         specifier: ^0.34.5
         version: 0.34.5
@@ -204,9 +205,6 @@ importers:
       '@web-std/file':
         specifier: ^3.0.3
         version: 3.0.3
-      hono:
-        specifier: ^4.3.2
-        version: 4.3.2
     devDependencies:
       '@hono/node-server':
         specifier: ^1.2.0
@@ -217,6 +215,9 @@ importers:
       '@types/supertest':
         specifier: ^2.0.12
         version: 2.0.12
+      hono:
+        specifier: ^4.3.2
+        version: 4.3.2
       supertest:
         specifier: ^6.3.3
         version: 6.3.3
@@ -232,9 +233,6 @@ importers:
       '@hono-storage/core':
         specifier: workspace:*
         version: link:../core
-      hono:
-        specifier: ^4.3.2
-        version: 4.3.2
     devDependencies:
       '@smithy/types':
         specifier: ^2.4.0
@@ -242,6 +240,9 @@ importers:
       '@web-std/file':
         specifier: ^3.0.3
         version: 3.0.3
+      hono:
+        specifier: ^4.3.2
+        version: 4.3.2
 
   website:
     devDependencies:
@@ -4365,7 +4366,6 @@ packages:
   /hono@4.3.2:
     resolution: {integrity: sha512-wiZcF5N06tc232U11DnqW6hP8DNoypjsrxslKXfvOqOAkTdh7K1HLZJH/92Mf+urxUTGi96f1w4xx/1Qozoqiw==}
     engines: {node: '>=16.0.0'}
-    dev: false
 
   /hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}

--- a/website/package.json
+++ b/website/package.json
@@ -10,12 +10,5 @@
   "devDependencies": {
     "vitepress": "1.0.0-rc.25",
     "vue": "^3.3.7"
-  },
-  "pnpm": {
-    "peerDependencyRules": {
-      "ignoreMissing": [
-        "@algolia/client-search"
-      ]
-    }
   }
 }


### PR DESCRIPTION
supports `hono@>=3.8` because using `c.req.parseBody({ all: true })` internally

https://github.com/honojs/hono/releases/tag/v3.8.0