### PR TITLE
feat(disk): add a field for generated filenames

### DIFF
--- a/.changeset/orange-turtles-divide.md
+++ b/.changeset/orange-turtles-divide.md
@@ -1,0 +1,8 @@
+---
+"@hono-storage/node-disk": patch
+---
+
+Add fileNames field to access generated filenames if filename option is set
+
+This adds a `fileNames` field for `nodejs-disk` package to return the generated file names if filename option was used when initializing.
+The approach is highly similar to `signedURLs` field in `s3` package.

--- a/.changeset/orange-turtles-divide.md
+++ b/.changeset/orange-turtles-divide.md
@@ -1,5 +1,5 @@
 ---
-"@hono-storage/node-disk": patch
+"@hono-storage/node-disk": minor
 ---
 
 Add fileNames field to access generated filenames if filename option is set

--- a/packages/node-disk/src/index.ts
+++ b/packages/node-disk/src/index.ts
@@ -26,11 +26,14 @@ interface HonoDiskStorageOption {
   filename?: HDSCustomFunction;
 }
 
-export class HonoDiskStorage {
+export class HonoDiskStorage<
+  Option extends HonoDiskStorageOption,
+  WithFilename = Option["filename"] extends HDSCustomFunction ? true : false,
+> {
   private storage: HonoStorage;
 
-  constructor(option: HonoDiskStorageOption = {}) {
-    const { dest = "/tmp" } = option;
+  constructor(option: Option) {
+    const { dest = "/tmp" } = option ?? {};
 
     this.storage = new HonoStorage({
       storage: async (c, files) => {
@@ -93,9 +96,11 @@ export class HonoDiskStorage {
       [FILES_KEY]: {
         [key in T]?: FieldValue;
       };
-      [FILE_NAMES_KEY]: {
-        [key in T]: string;
-      };
+      [FILE_NAMES_KEY]: WithFilename extends true
+        ? {
+            [key in T]: string;
+          }
+        : {};
     };
   }> => {
     return async (c, next) => {
@@ -115,9 +120,11 @@ export class HonoDiskStorage {
       [FILES_KEY]: {
         [key in T]?: FieldValue;
       };
-      [FILE_NAMES_KEY]: {
-        [key in T]: string[];
-      };
+      [FILE_NAMES_KEY]: WithFilename extends true
+        ? {
+            [key in T]: string[];
+          }
+        : {};
     };
   }> => {
     return async (c, next) => {
@@ -138,9 +145,13 @@ export class HonoDiskStorage {
           ? FieldValue | undefined
           : FieldValue[];
       };
-      [FILE_NAMES_KEY]: {
-        [key in keyof T]: T[key]["type"] extends "single" ? string : string[];
-      };
+      [FILE_NAMES_KEY]: WithFilename extends true
+        ? {
+            [key in keyof T]: T[key]["type"] extends "single"
+              ? string
+              : string[];
+          }
+        : {};
     };
   }> => {
     return async (c, next) => {

--- a/packages/node-disk/tests/index.test.ts
+++ b/packages/node-disk/tests/index.test.ts
@@ -118,5 +118,24 @@ describe("HonoDiskStorage", () => {
         }),
       );
     });
+
+    it("returns the uploaded file's filename", async () => {
+      const PREFIX = "prefix-";
+      const storage = new HonoDiskStorage({
+        dest: join(__dirname, "tmp"),
+        filename: (_, file) =>
+          `${PREFIX}${file.originalname}.${file.extension}`,
+      });
+      const app = new Hono();
+      app.post("/upload", storage.single("file"), (c) =>
+        c.text(c.var.fileNames.file),
+      );
+      const server = createAdaptorServer(app);
+      const res = await request(server)
+        .post("/upload")
+        .attach("file", join(__dirname, "fixture/sample1.txt"));
+      expect(res.status).toBe(200);
+      expect(res.text).toBe(`${PREFIX}sample1.txt`);
+    });
   });
 });


### PR DESCRIPTION
Fixes #76 and I guess also fixes #75 

This PR adds a `fileNames` field for `nodejs-disk` package to return the generated file names if `filename` option was used when initializing.

The approach is highly similar to `signedURLs` field in `s3` package.
I'm not 100% sure if `fileNames` is the best name to use so I'm really open to suggestions about that.

Any feedback is appreciated!
